### PR TITLE
Fix dashed lines bug

### DIFF
--- a/project/build/astrochart.js
+++ b/project/build/astrochart.js
@@ -3549,7 +3549,7 @@
 		for(var i = 0, ln = points.length; i < ln ; i++ ){
 										
 			if( Math.abs(points[i].angle - angle) <= collisionRadius || 
-			(deg360 - Math.abs(points[i].angle - angle)) <= collisionRadius){
+			Math.abs(deg360 - Math.abs(points[i].angle - angle)) <= collisionRadius){
 				result = true;
 				break;
 			}					


### PR DESCRIPTION
astrology.utils.isInCollision was returning incorrect collisions, resulting in unnecessary dashed lines via astrology.utils.getDashedLinesPositions.