### PR TITLE
add viewBox to svg to make it responsive

### DIFF
--- a/project/src/svg.js
+++ b/project/src/svg.js
@@ -19,7 +19,8 @@
 		svg.setAttribute('style', "position: relative; overflow: hidden;");		
 		svg.setAttribute('version', "1.1");						 				
 		svg.setAttribute('width', width);
-		svg.setAttribute('height', height);									
+		svg.setAttribute('height', height);		
+		svg.setAttribute('viewBox', "0 0 "+ width + " " + height);									
 		document.getElementById( elementId ).appendChild( svg );
 		
 		var wrapper = document.createElementNS(svg.namespaceURI, "g");


### PR DESCRIPTION
Adding the viewBox property to the svg, we can make it responsive. So if we change the width using css, the svg will respect it.